### PR TITLE
Return multiple errors from Writer.WriteMessages and MessageTooLargeError handling improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,37 @@ jobs:
       - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
       - run: go test -v -race -cover -timeout 150s $(go list ./... | grep -v examples)
 
+  kafka-221:
+    working_directory: /go/src/github.com/segmentio/kafka-go
+    environment:
+      KAFKA_VERSION: "2.2.1"
+    docker:
+      - image: circleci/golang
+      - image: wurstmeister/zookeeper
+        ports: ['2181:2181']
+      - image: wurstmeister/kafka:2.12-2.2.1
+        ports: ['9092:9092','9093:9093']
+        environment:
+          KAFKA_BROKER_ID: '1'
+          KAFKA_CREATE_TOPICS: 'test-writer-0:3:1,test-writer-1:3:1'
+          KAFKA_DELETE_TOPIC_ENABLE: 'true'
+          KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+          KAFKA_ADVERTISED_PORT: '9092'
+          KAFKA_ZOOKEEPER_CONNECT: 'localhost:2181'
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+          KAFKA_LISTENERS: 'PLAINTEXT://:9092,SASL_PLAINTEXT://:9093'
+          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093'
+          KAFKA_SASL_ENABLED_MECHANISMS: SCRAM-SHA-256,SCRAM-SHA-512,PLAIN
+          KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/kafka_server_jaas.conf"
+          CUSTOM_INIT_SCRIPT: |-
+            echo -e 'KafkaServer {\norg.apache.kafka.common.security.scram.ScramLoginModule required\n username="adminscram"\n password="admin-secret";\n org.apache.kafka.common.security.plain.PlainLoginModule required\n username="adminplain"\n password="admin-secret"\n user_adminplain="admin-secret";\n  };' > /opt/kafka/config/kafka_server_jaas.conf;
+            /opt/kafka/bin/kafka-configs.sh --zookeeper localhost:2181 --alter --add-config 'SCRAM-SHA-256=[password=admin-secret-256],SCRAM-SHA-512=[password=admin-secret-512]' --entity-type users --entity-name adminscram
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t . ./gzip ./lz4 ./sasl ./snappy
+      - run: go test -v -race -cover -timeout 150s $(go list ./... | grep -v examples)
+
 workflows:
   version: 2
   run:
@@ -131,3 +162,4 @@ workflows:
       - kafka-011
       - kafka-111
       - kafka-210
+      - kafka-221

--- a/writer.go
+++ b/writer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -148,6 +149,24 @@ func (e *WriterError) Temporary() bool {
 
 func (e *WriterError) Timeout() bool {
 	return isTimeout(e.Err)
+}
+
+type WriterErrors []WriterError
+
+func (es WriterErrors) Error() string {
+	if len(es) == 1 {
+		return fmt.Sprintf("1 WriterError occurred:\n\t* %s\n", es[0].Err)
+	}
+
+	points := make([]string, len(es))
+	for i, we := range es {
+		points[i] = fmt.Sprintf("* %s", we.Err)
+	}
+
+	return fmt.Sprintf(
+		"%d WriterErrors occurred:\n\t%s\n",
+		len(es),
+		strings.Join(points, "\n\t"))
 }
 
 // WriterStats is a data structure returned by a call to Writer.Stats that

--- a/writer.go
+++ b/writer.go
@@ -855,7 +855,7 @@ type writerMessage struct {
 
 type writerResponse struct {
 	id  int
-	err error
+	err *WriterError
 }
 
 func shuffledStrings(list []string) []string {

--- a/writer.go
+++ b/writer.go
@@ -133,6 +133,27 @@ type WriterConfig struct {
 	newPartitionWriter func(partition int, config WriterConfig, stats *writerStats) partitionWriter
 }
 
+type WriterError struct {
+	Msg Message
+	Err error
+}
+
+func (e *WriterError) Cause() error {
+	return e.Err
+}
+
+func (e *WriterError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *WriterError) Temporary() bool {
+	return isTemporary(e.Err)
+}
+
+func (e *WriterError) Timeout() bool {
+	return isTimeout(e.Err)
+}
+
 // WriterStats is a data structure returned by a call to Writer.Stats that
 // exposes details about the behavior of the writer.
 type WriterStats struct {
@@ -782,27 +803,6 @@ func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret
 type writerMessage struct {
 	msg Message
 	res chan<- error
-}
-
-type WriterError struct {
-	Msg Message
-	Err error
-}
-
-func (e *WriterError) Cause() error {
-	return e.Err
-}
-
-func (e *WriterError) Error() string {
-	return e.Err.Error()
-}
-
-func (e *WriterError) Temporary() bool {
-	return isTemporary(e.Err)
-}
-
-func (e *WriterError) Timeout() bool {
-	return isTimeout(e.Err)
 }
 
 func shuffledStrings(list []string) []string {

--- a/writer.go
+++ b/writer.go
@@ -138,10 +138,6 @@ type WriterError struct {
 	Err error
 }
 
-func (e *WriterError) Cause() error {
-	return e.Err
-}
-
 func (e *WriterError) Error() string {
 	return e.Err.Error()
 }

--- a/writer.go
+++ b/writer.go
@@ -351,6 +351,7 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 			case w.msgs <- writerMessage{
 				msg: msg,
 				res: res,
+				id:  i,
 			}:
 			case <-ctx.Done():
 				w.mutex.RUnlock()

--- a/writer.go
+++ b/writer.go
@@ -153,19 +153,19 @@ func (e *WriterError) Timeout() bool {
 
 type WriterErrors []WriterError
 
-func (es WriterErrors) Error() string {
-	if len(es) == 1 {
-		return fmt.Sprintf("1 WriterError occurred:\n\t* %s\n", es[0].Err)
+func (wes WriterErrors) Error() string {
+	if len(wes) == 1 {
+		return fmt.Sprintf("1 WriterError occurred:\n\t* %s\n", wes[0].Err)
 	}
 
-	points := make([]string, len(es))
-	for i, we := range es {
+	points := make([]string, len(wes))
+	for i, we := range wes {
 		points[i] = fmt.Sprintf("* %s", we.Err)
 	}
 
 	return fmt.Sprintf(
 		"%d WriterErrors occurred:\n\t%s\n",
-		len(es),
+		len(wes),
 		strings.Join(points, "\n\t"))
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -148,8 +148,12 @@ func (f *fakeWriter) messages() chan<- writerMessage {
 	go func() {
 		for {
 			msg := <-ch
-			msg.res <- &WriterError{
-				Err: errors.New("bad attempt"),
+			msg.res <- writerResponse{
+				id: msg.id,
+				err: &WriterError{
+					Err: errors.New("bad attempt"),
+					Msg: msg.msg,
+				},
 			}
 		}
 	}()

--- a/writer_test.go
+++ b/writer_test.go
@@ -58,6 +58,69 @@ func TestWriter(t *testing.T) {
 	}
 }
 
+type writerTestCase WriterErrors
+
+func (wt writerTestCase) errorsEqual(wes WriterErrors) bool {
+	exp := make(map[string]int)
+	numExp := 0
+	for _, t := range wt {
+		if t.Err != nil {
+			numExp += 1
+			k := string(t.Msg.Value) + t.Err.Error()
+			if _, ok := exp[k]; ok {
+				exp[k] += 1
+			} else {
+				exp[k] = 1
+			}
+		}
+	}
+
+	if len(wes) != numExp {
+		return false
+	}
+
+	for _, e := range wes {
+		k := string(e.Msg.Value) + e.Err.Error()
+		if _, ok := exp[k]; ok {
+			exp[k] -= 1
+		} else {
+			return false
+		}
+	}
+
+	for _, e := range exp {
+		if e != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (wt writerTestCase) msgs() []Message {
+	msgs := make([]Message, len(wt))
+	for i, m := range wt {
+		msgs[i] = m.Msg
+	}
+
+	return msgs
+}
+
+func (wt writerTestCase) expected() WriterErrors {
+	exp := make(WriterErrors, 0, len(wt))
+	for _, v := range wt {
+		if v.Err != nil {
+			exp = append(exp, v)
+		}
+	}
+
+	if len(exp) > 0 {
+		return exp
+	}
+
+	return nil
+}
+
 func newTestWriter(config WriterConfig) *Writer {
 	if len(config.Brokers) == 0 {
 		config.Brokers = []string{"localhost:9092"}

--- a/writer_test.go
+++ b/writer_test.go
@@ -148,8 +148,8 @@ func (f *fakeWriter) messages() chan<- writerMessage {
 	go func() {
 		for {
 			msg := <-ch
-			msg.res <- &writerError{
-				err: errors.New("bad attempt"),
+			msg.res <- &WriterError{
+				Err: errors.New("bad attempt"),
 			}
 		}
 	}()

--- a/writer_test.go
+++ b/writer_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"math"
-	"strings"
 	"testing"
 	"time"
 )
@@ -21,12 +20,22 @@ func TestWriter(t *testing.T) {
 			scenario: "closing a writer right after creating it returns promptly with no error",
 			function: testWriterClose,
 		},
-
+		{
+			scenario: "writing messages on closed writer should return error",
+			function: testClosedWriterErr,
+		},
+		{
+			scenario: "writing empty Message slice returns promptly with no error",
+			function: testEmptyWrite,
+		},
+		{
+			scenario: "writing messages after context is done should return an error",
+			function: testContextDoneErr,
+		},
 		{
 			scenario: "writing 1 message through a writer using round-robin balancing produces 1 message to the first partition",
 			function: testWriterRoundRobin1,
 		},
-
 		{
 			scenario: "running out of max attempts should return an error",
 			function: testWriterMaxAttemptsErr,
@@ -46,6 +55,10 @@ func TestWriter(t *testing.T) {
 		{
 			scenario: "writing messsages with a small batch byte size",
 			function: testWriterSmallBatchBytes,
+		},
+		{
+			scenario: "writing messages with retries enabled",
+			function: testWriterRetries,
 		},
 	}
 
@@ -141,6 +154,120 @@ func testWriterClose(t *testing.T) {
 	}
 }
 
+func testClosedWriterErr(t *testing.T) {
+	tcs := []writerTestCase{
+		{
+			{
+				Msg: Message{Value: []byte("Hello World!")},
+				Err: io.ErrClosedPipe,
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("Hello")},
+				Err: io.ErrClosedPipe,
+			},
+			{
+				Msg: Message{Value: []byte("World!")},
+				Err: io.ErrClosedPipe,
+			},
+		},
+	}
+
+	const topic = "test-writer-0"
+	w := newTestWriter(WriterConfig{
+		Topic: topic,
+	})
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range tcs {
+		err := w.WriteMessages(context.Background(), tc.msgs()...)
+		if err == nil {
+			t.Errorf("test %d: expected error", i)
+			continue
+		}
+
+		wes, ok := err.(WriterErrors)
+		if !ok {
+			t.Errorf("test %d: expected WriterErrors", i)
+			continue
+		}
+
+		if !tc.errorsEqual(wes) {
+			t.Errorf("test %d: unexpected errors occurred.\nExpected:\n%sFound:\n%s", i, tc.expected(), wes)
+		}
+	}
+}
+
+func testEmptyWrite(t *testing.T) {
+	const topic = "test-writer-0"
+	w := newTestWriter(WriterConfig{
+		Topic: topic,
+	})
+
+	defer func() {
+		_ = w.Close()
+	}()
+
+	if err := w.WriteMessages(context.Background(), []Message{}...); err != nil {
+		t.Error("unexpected error occurred", err)
+	}
+}
+
+func testContextDoneErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tcs := []writerTestCase{
+		{
+			{
+				Msg: Message{Value: []byte("Hello World!")},
+				Err: ctx.Err(),
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("Hello")},
+				Err: ctx.Err(),
+			},
+			{
+				Msg: Message{Value: []byte("World")},
+				Err: ctx.Err(),
+			},
+		},
+	}
+
+	const topic = "test-writer-0"
+	w := newTestWriter(WriterConfig{
+		Topic: topic,
+	})
+
+	defer func() {
+		_ = w.Close()
+	}()
+
+	for i, tc := range tcs {
+		err := w.WriteMessages(ctx, tc.msgs()...)
+		if err == nil {
+			t.Errorf("test %d: expected error", i)
+			continue
+		}
+
+		wes, ok := err.(WriterErrors)
+		if !ok {
+			t.Errorf("test %d: expected WriterErrors", i)
+			continue
+		}
+
+		if !tc.errorsEqual(wes) {
+			t.Errorf("test %d: unexpected errors occurred.\nExpected:\n%sFound:\n%s", i, tc.expected(), wes)
+		}
+	}
+}
+
 func testWriterRoundRobin1(t *testing.T) {
 	const topic = "test-writer-1"
 
@@ -203,9 +330,9 @@ func TestValidateWriter(t *testing.T) {
 	}
 }
 
-type fakeWriter struct{}
+type errorWriter struct{}
 
-func (f *fakeWriter) messages() chan<- writerMessage {
+func (w *errorWriter) messages() chan<- writerMessage {
 	ch := make(chan writerMessage, 1)
 
 	go func() {
@@ -224,46 +351,99 @@ func (f *fakeWriter) messages() chan<- writerMessage {
 	return ch
 }
 
-func (f *fakeWriter) close() {
+func (w *errorWriter) close() {
 
 }
 
 func testWriterMaxAttemptsErr(t *testing.T) {
+	tcs := []writerTestCase{
+		{
+			{
+				Msg: Message{Value: []byte("test 1 error")},
+				Err: errors.New("bad attempt"),
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("test multi error")},
+				Err: errors.New("bad attempt"),
+			},
+			{
+				Msg: Message{Value: []byte("test multi error")},
+				Err: errors.New("bad attempt"),
+			},
+		},
+	}
+
 	const topic = "test-writer-2"
 
 	createTopic(t, topic, 1)
 	w := newTestWriter(WriterConfig{
 		Topic:       topic,
-		MaxAttempts: 1,
+		MaxAttempts: 2,
 		Balancer:    &RoundRobin{},
-		newPartitionWriter: func(p int, config WriterConfig, stats *writerStats) partitionWriter {
-			return &fakeWriter{}
+		newPartitionWriter: func(_ int, _ WriterConfig, _ *writerStats) partitionWriter {
+			return &errorWriter{}
 		},
 	})
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 
-	if err := w.WriteMessages(context.Background(), Message{
-		Value: []byte("Hello World!"),
-	}); err == nil {
-		t.Error("expected error")
-		return
-	} else if err != nil {
-		if !strings.Contains(err.Error(), "bad attempt") {
-			t.Errorf("unexpected error: %s", err)
-			return
+	for i, tc := range tcs {
+		err := w.WriteMessages(context.Background(), tc.msgs()...)
+		if err == nil {
+			t.Errorf("test %d: expected error", i)
+			continue
+		}
+
+		wes, ok := err.(WriterErrors)
+		if !ok {
+			t.Errorf("test %d: expected WriterErrors", i)
+			continue
+		}
+
+		if !tc.errorsEqual(wes) {
+			t.Errorf("test %d: unexpected errors occurred.\nExpected:\n%sFound:\n%s", i, tc.expected(), wes)
 		}
 	}
 }
 
 func testWriterMaxBytes(t *testing.T) {
-	topic := makeTopic()
+	tcs := []writerTestCase{
+		{
+			{
+				Msg: Message{Value: []byte("Hello World!")},
+				Err: MessageTooLargeError{},
+			},
+			{
+				Msg: Message{Value: []byte("Hi")},
+				Err: nil,
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("Too large!")},
+				Err: MessageTooLargeError{},
+			},
+			{
+				Msg: Message{Value: []byte("Also too long!")},
+				Err: MessageTooLargeError{},
+			},
+		},
+	}
 
+	topic := makeTopic()
+	maxBytes := 25
 	createTopic(t, topic, 1)
 	w := newTestWriter(WriterConfig{
 		Topic:      topic,
-		BatchBytes: 25,
+		BatchBytes: maxBytes,
 	})
-	defer w.Close()
+
+	defer func() {
+		_ = w.Close()
+	}()
 
 	if err := w.WriteMessages(context.Background(), Message{
 		Value: []byte("Hi"),
@@ -272,37 +452,21 @@ func testWriterMaxBytes(t *testing.T) {
 		return
 	}
 
-	firstMsg := []byte("Hello World!")
-	secondMsg := []byte("LeftOver!")
-	msgs := []Message{
-		{
-			Value: firstMsg,
-		},
-		{
-			Value: secondMsg,
-		},
-	}
-	if err := w.WriteMessages(context.Background(), msgs...); err == nil {
-		t.Error("expected error")
-		return
-	} else if err != nil {
-		switch e := err.(type) {
-		case MessageTooLargeError:
-			if string(e.Message.Value) != string(firstMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", firstMsg, e.Message.Value)
-				return
-			}
-			if len(e.Remaining) != 1 {
-				t.Error("expected remaining errors; found none")
-				return
-			}
-			if string(e.Remaining[0].Value) != string(secondMsg) {
-				t.Errorf("unxpected returned message. Expected: %s, Got %s", secondMsg, e.Message.Value)
-				return
-			}
-		default:
-			t.Errorf("unexpected error: %s", err)
-			return
+	for i, tc := range tcs {
+		err := w.WriteMessages(context.Background(), tc.msgs()...)
+		if err == nil {
+			t.Errorf("test %d: expected error", i)
+			continue
+		}
+
+		wes, ok := err.(WriterErrors)
+		if !ok {
+			t.Errorf("test %d: expected WriterErrors", i)
+			continue
+		}
+
+		if !tc.errorsEqual(wes) {
+			t.Errorf("test %d: unexpected errors occurred.\nExpected:\n%sFound:\n%s", i, tc.expected(), wes)
 		}
 	}
 }
@@ -496,5 +660,108 @@ func testWriterSmallBatchBytes(t *testing.T) {
 			continue
 		}
 		t.Error("bad messages in partition", msgs)
+	}
+}
+
+type testRetryWriter struct {
+	errs int
+}
+
+func (w *testRetryWriter) messages() chan<- writerMessage {
+	ch := make(chan writerMessage, 1)
+
+	go func() {
+		for {
+			msg := <-ch
+			if w.errs > 0 {
+				msg.res <- writerResponse{
+					id: msg.id,
+					err: &WriterError{
+						Msg: msg.msg,
+						Err: errors.New("bad attempt"),
+					},
+				}
+				w.errs -= 1
+			} else {
+				msg.res <- writerResponse{
+					id:  msg.id,
+					err: nil,
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (w *testRetryWriter) close() {
+
+}
+
+func testWriterRetries(t *testing.T) {
+	tcs := []writerTestCase{
+		{
+			{
+				Msg: Message{Value: []byte("test message 1")},
+				Err: nil,
+			},
+			{
+				Msg: Message{Value: []byte("test message 2")},
+				Err: nil,
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("these messages")},
+				Err: nil,
+			},
+			{
+				Msg: Message{Value: []byte("should succeed")},
+				Err: nil,
+			},
+			{
+				Msg: Message{Value: []byte("for this test case")},
+				Err: nil,
+			},
+		},
+		{
+			{
+				Msg: Message{Value: []byte("this message should fail")},
+				Err: errors.New("bad attempt"),
+			},
+		},
+	}
+
+	const topic = "test-writer-retry"
+	createTopic(t, topic, 1)
+
+	for i, tc := range tcs {
+		w := newTestWriter(WriterConfig{
+			Topic:       topic,
+			MaxAttempts: 2,
+			Balancer:    &RoundRobin{},
+			newPartitionWriter: func(_ int, _ WriterConfig, _ *writerStats) partitionWriter {
+				return &testRetryWriter{errs: 2}
+			},
+		})
+
+		err := w.WriteMessages(context.Background(), tc.msgs()...)
+		if err == nil {
+			if tc.expected() != nil {
+				t.Errorf("test %d: expected error", i)
+			}
+		} else {
+			if wes, ok := err.(WriterErrors); !ok {
+				t.Errorf("test %d: expected WriterErrors", i)
+			} else {
+				if !tc.errorsEqual(wes) {
+					t.Errorf("test %d: unexpected errors occurred.\nExpected:\n%sFound:\n%s", i, tc.expected(), wes)
+				}
+			}
+		}
+
+		if err = w.Close(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Addresses issues 363 and 364

This PR revolves around 2 main improvements for the Writer type:

Return information about all errors that occurred during a write of multiple messages while still preserving interface of Writer.WriteMessages
Try to send all acceptable messages in a batch before returning the ones that are too large
I introduced two new public types, WriterError and WriterErrors to implement the first improvement. Both implement the error interface. Under the hood Writer.WriteMessages returns WriterErrors. The caller can cast the error returned as WriterErrors to use the new functionality if they so choose.

The second improvement is addressed by skipping messages that are too large as the Writer comes across them while sending to the msgs channel. They are instead stored as errors that will be returned after all the other messages have been tried.

New tests have been added to writer_test.go to ensure these features behave as expected. Additionally, some of the preexisting tests have been updated so they also check the WriterErrors returned.

There would have been a bunch of merge conflicts and wasted work if I tried to made both improvements individually so I decided to knock out two birds with one stone.